### PR TITLE
Validate comments before sending to API to prevent validation issues

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -176,8 +176,13 @@ button, input[type="button"], input[type="submit"], .btn {
   font-size: 1.5rem;
   box-sizing: border-box;
   display: block;
+  cursor: pointer;
 }
-
+button:disabled {
+  background: lightgrey;
+  border-color: lightgrey;
+  cursor: default;
+}
 a.btn {
   display: inline-block;
   text-decoration: none;

--- a/pages/posts/_slug.vue
+++ b/pages/posts/_slug.vue
@@ -19,7 +19,7 @@
         <textarea class="form-control" v-model="comment" wrap="soft" rows="1"
                   placeholder="Share your thoughts..." v-on:click="expandCommentTextArea($event)"
                   v-on:blur="collapseCommentTextArea($event)" :disabled="postingComment"></textarea>
-        <button type="submit" class="btn btn-primary" :disabled="postingComment">Submit</button>
+        <button type="submit" class="btn btn-primary" :disabled="!canSubmitComment">Submit</button>
       </form>
     </div>
 
@@ -42,6 +42,11 @@ export default {
       commentPage: 1,
       commentPageCount: 1
     };
+  },
+  computed: {
+    canSubmitComment() {
+      return this.comment.length >= 10 && !this.postingComment;
+    }
   },
   async asyncData({params, $axios}) {
     const post = await $axios.$get(`/api/posts/${params.slug}`);
@@ -73,6 +78,13 @@ export default {
       }
       this.postingComment = true;
 
+      // Validate.
+      if (this.comment.length < 10) {
+        // Must be longer than 10 characters
+        this.postingComment = false;
+        return;
+      }
+
       this.$axios.post(`/api/posts/${this.post.id}/comments`, {
         comment: this.comment
       }).then(() => {
@@ -84,6 +96,7 @@ export default {
         });
         // Clear comment textarea.
         this.comment = '';
+      }).finally(() => {
         this.postingComment = false;
       });
     },

--- a/pages/posts/_slug.vue
+++ b/pages/posts/_slug.vue
@@ -72,11 +72,10 @@ export default {
       });
     },
     submitComment() {
-      if (!this.$auth.loggedIn) {
+      if (!this.$auth.loggedIn || this.postingComment) {
         // How did we get here?!
         return;
       }
-      this.postingComment = true;
 
       // Validate.
       if (this.comment.length < 10) {
@@ -84,6 +83,8 @@ export default {
         this.postingComment = false;
         return;
       }
+
+      this.postingComment = true;
 
       this.$axios.post(`/api/posts/${this.post.id}/comments`, {
         comment: this.comment


### PR DESCRIPTION
fix #1 

### Issue

API validation for invalid comments is not handled in the front end and breaks functionality of the commenting section.

### Resolution

Added a new computed property in the posts/_slug.vue page to calculate the disabled state of the comment button, based off the postingComment data boolean flag along with the content length of the comment textarea.

Also added styling for disabled buttons in the default template to better display that but button is disabled.

### Testing

Pull branch
Follow main readme to setup the project
Attempt to make an invalid comment by either leaving the comment field blank or entering less than 10 characters.

### Expected Result
The submit button for the comment section remains disabled. In the event the button is enabled some how (I.E DOM manipulation) the request is prevented.