### PR TITLE
Add missing admin menu component

### DIFF
--- a/layouts/home.vue
+++ b/layouts/home.vue
@@ -23,6 +23,8 @@
         </div>
       </div>
     </div>
+
+    <AdminMenu/>
   </div>
 </template>
 


### PR DESCRIPTION
#11
Add the missing AdminMenu component to the home layout.

The AdminMenu component which generates the admin menu was missing. Added this back in to the home layout.