### PR TITLE
Fix Nav Highlight

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -89,7 +89,7 @@ a:hover {
   transition: background-color 0.2s linear;
 }
 
-.navbar .nav .nav-item > a:hover, .navbar .nav .nav-item a.selected {
+.navbar .nav .nav-item > a:hover, .navbar .nav .nav-item a.selected, .nuxt-link-exact-active {
   color: var(--color_primary);
   text-decoration: none;
   background-color: #eee;


### PR DESCRIPTION
close #18 

### Issue
Active nav item was not highlighted correctly

### Fix
Added missing class reference to stylesheet.

### Testing
1. Check home page is highlighted on the nav bar
2. **Click** on the About link and check the About item is now highlighted 